### PR TITLE
Feature/fov shrinker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ python/.tox/
 python/**/*.egg-info/
 python/**/*.so
 python/**/*.dll
+.vscode/

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,63 @@ reading and visualizing data, and interfacing with ROS.
 * `ouster_ros <ouster_ros/>`_ contains example ROS nodes for publishing point cloud messages
 * `python <python/>`_ contains the code for the ouster sensor python SDK (``ouster-sdk`` Python package)
 
+FOV Shrinker Feature
+====================
+
+Purpose
+-------
+
+The FOV (Field of View) Shrinker is an integrated beam filtering feature in the ROS point cloud node that allows users to reduce the vertical field of view by selecting only specific horizontal beam ranges from the LiDAR sensor. This feature is particularly useful for:
+
+* **Performance optimization**: Reducing computational load by processing fewer points
+* **Focus on region of interest**: Concentrating on specific vertical sections (e.g., road level, horizon)
+* **Bandwidth reduction**: Decreasing network traffic in distributed systems
+
+Usage
+-----
+
+The FOV shrinker can be controlled through ROS parameters:
+
+**Enable/Disable Filtering:**
+
+.. code-block:: xml
+
+    <!-- In your launch file -->
+    <param name="/os_cloud_node/enable_FOV_filter" value="true"/>
+
+**Configure Beam Range:**
+
+.. code-block:: xml
+
+    <!-- Keep beams 16 to 48 (middle section of a 64-beam LiDAR) -->
+    <param name="/os_cloud_node/start_beam" value="16"/>
+    <param name="/os_cloud_node/end_beam" value="48"/>
+    
+    <!-- Enable debug output for performance monitoring -->
+    <param name="/os_cloud_node/debug_mode" value="false"/>
+
+**Command Line Usage:**
+
+.. code-block:: bash
+
+    # Launch with filtering enabled (default: middle half beams)
+    roslaunch ouster_ros ouster.launch enable_FOV_filter:=true
+    
+    # Launch with custom beam range
+    roslaunch ouster_ros ouster.launch enable_FOV_filter:=true start_beam:=10 end_beam:=40
+    
+    # Launch with debug output enabled
+    roslaunch ouster_ros ouster.launch enable_FOV_filter:=true debug_mode:=true
+
+**Default Behavior:**
+
+* **Filter disabled by default**: Full point cloud is published when no parameters are set
+* **Middle half beams**: When enabled without specifying ranges, keeps beams from 25% to 75% of total beam count
+* **Automatic beam calculation**: Default start/end beams are calculated based on sensor configuration
+
+
+The filtered point cloud maintains all original metadata and is published to the same topics (/os_cloud_node/points) as the full point cloud 
+
 
 License
 ========

--- a/ouster_ros/ouster.launch
+++ b/ouster_ros/ouster.launch
@@ -12,6 +12,7 @@
   <arg name="rviz_config" default="-d $(find ouster_ros)/viz.rviz" doc="optional rviz config file"/>
   <arg name="tf_prefix" default="" doc="namespace for tf transforms"/>
   <arg name="udp_profile_lidar" default="" doc="lidar packet profile: LEGACY, RNG19_RFL8_SIG16_NIR16_DUAL, RNG19_RFL8_SIG16_NIR16, RNG15_RFL8_NIR8"/>
+  <arg name="fov_shrinker" default="false" doc="enable shrinking field of view"/>
 
   <node pkg="ouster_ros" name="os_node" type="os_node" output="screen" required="true">
     <param name="~/lidar_mode" type="string" value="$(arg lidar_mode)"/>
@@ -23,6 +24,7 @@
     <param name="~/imu_port" value="$(arg imu_port)"/>
     <param name="~/metadata" value="$(arg metadata)"/>
     <param name="~/udp_profile_lidar" value="$(arg udp_profile_lidar)"/>
+    <param name="~/enable_FOV_filter" value="$(arg fov_shrinker)"/>
   </node>
 
   <node pkg="ouster_ros" type="os_cloud_node" name="os_cloud_node" output="screen" required="true">

--- a/ouster_ros/ouster.launch
+++ b/ouster_ros/ouster.launch
@@ -24,7 +24,7 @@
     <param name="~/imu_port" value="$(arg imu_port)"/>
     <param name="~/metadata" value="$(arg metadata)"/>
     <param name="~/udp_profile_lidar" value="$(arg udp_profile_lidar)"/>
-    <param name="~/enable_FOV_filter" value="$(arg fov_shrinker)"/>
+
   </node>
 
   <node pkg="ouster_ros" type="os_cloud_node" name="os_cloud_node" output="screen" required="true">
@@ -32,6 +32,8 @@
     <remap from="~/lidar_packets" to="/os_node/lidar_packets"/>
     <remap from="~/imu_packets" to="/os_node/imu_packets"/>
     <param name="~/tf_prefix" value="$(arg tf_prefix)"/>
+    <param name="~/enable_FOV_filter" value="$(arg fov_shrinker)"/>
+    <param name="~/debug_mode" value="true"/>
   </node>
 
   <node if="$(arg viz)" pkg="rviz" name="rviz" type="rviz" args="$(arg rviz_config)" output="screen" required="true" />

--- a/ouster_ros/src/os_cloud_node.cpp
+++ b/ouster_ros/src/os_cloud_node.cpp
@@ -136,31 +136,46 @@ int main(int argc, char** argv) {
         return std::to_string(ind + 1);  // need second return to return 2
     };
 
-    // auto lidar_pubs = std::vector<ros::Publisher>();
-    // for (int i = 0; i < n_returns; i++) {
-    //     auto pub = nh.advertise<sensor_msgs::PointCloud2>(
-    //         std::string("points") + img_suffix(i), 10);
-    //     lidar_pubs.push_back(pub);
-    // }
+    auto lidar_pubs = std::vector<ros::Publisher>();
+    for (int i = 0; i < n_returns; i++) {
+        auto pub = nh.advertise<sensor_msgs::PointCloud2>(
+            std::string("points") + img_suffix(i), 10);
+        lidar_pubs.push_back(pub);
+    }
 
     //============= part of FOV shrinker ===================
     // parameter for beam selection
 
     uint32_t n_beams = H;
-    int start_beam_int = nh.param("start_beam", (int)(n_beams/4));
-    int end_beam_int = nh.param("end_beam", (int)(start_beam_int + n_beams/2));
-    uint32_t start_beam = static_cast<uint32_t>(std::max(0, start_beam_int));
-    uint32_t end_beam = static_cast<uint32_t>(std::max(0, end_beam_int));
+
+    bool filter_enabled = nh.param("enable_FOV_filter", false);  //  default to off
+
+    // Only get other parameters if FOV filter is enabled
+    int start_beam_int = 0;
+    int end_beam_int = 0;
+    uint32_t start_beam = 0;
+    uint32_t end_beam = 0;
     bool debug_mode = nh.param("debug_mode", false);
 
-    std::vector<ros::Publisher> fov_pubs;
-    for (int i = 0; i < n_returns; i++){
-        auto pub = nh.advertise<sensor_msgs::PointCloud2>(std::string("points")+img_suffix(i), 10);
-        fov_pubs.push_back(pub);
+    if (filter_enabled){
+        start_beam_int = nh.param("start_beam", (int)(n_beams/4));
+        end_beam_int = nh.param("end_beam", (int)(start_beam_int + n_beams/2));
+        start_beam = static_cast<uint32_t>(std::max(0, start_beam_int));
+        end_beam = static_cast<uint32_t>(std::max(0, end_beam_int));
+
+        ROS_INFO("FOV point cloud filtering initialized");
+        ROS_INFO("Keeping beams %u to %u (of %u beams)", start_beam, end_beam-1, n_beams);
+    } else {
+        ROS_INFO("FOV point cloud filtering disabled");
     }
 
-    ROS_INFO("FOV point cloud filtering initialized");
-    ROS_INFO("Keeping beams %u to %u (of %u beams)", start_beam, end_beam-1, n_beams);
+    // std::vector<ros::Publisher> fov_pubs;
+    // for (int i = 0; i < n_returns; i++){
+    //     auto pub = nh.advertise<sensor_msgs::PointCloud2>(std::string("points")+img_suffix(i), 10);
+    //     fov_pubs.push_back(pub);
+    // }
+
+
    // ============= FOV shrinker ===================
 
     auto xyz_lut = ouster::make_xyz_lut(info);
@@ -190,8 +205,12 @@ int main(int argc, char** argv) {
                     // lidar_pubs[i].publish(cloud_msg);
 
                     //publish the FOV_clouds
-                    auto filtered_cloud = FOV_shrinker(cloud_msg, start_beam, end_beam, debug_mode);
-                    fov_pubs[i].publish(filtered_cloud);
+                    if (filter_enabled){
+                        auto filtered_cloud = FOV_shrinker(cloud_msg, start_beam, end_beam, debug_mode);
+                        lidar_pubs[i].publish(filtered_cloud);
+                    } else{
+                        lidar_pubs[i].publish(cloud_msg);
+                    }
                     // =============== FOV shrinker =======================
 
 

--- a/ouster_ros/src/os_cloud_node.cpp
+++ b/ouster_ros/src/os_cloud_node.cpp
@@ -28,6 +28,68 @@ using Cloud = ouster_ros::Cloud;
 using Point = ouster_ros::Point;
 namespace sensor = ouster::sensor;
 
+
+//============== begin new FOV shrinker ====================
+/**
+ * @brief Filter point clouds, to keep only the middle horizontal beams in the Field of View (FOV)
+ * @param start_beam starting beam index in FOV
+ * @param end_beam ending beam index in FOV
+ * @param debug Enable debug messages
+ */
+
+ sensor_msg::PointsClouds FOV_shrinker(
+    const sensor_msgs::PointCloud2& cloud_msg,
+    unit32_t start_beam,
+    unit32_t end_beam,
+    bool debug = false){
+        try{
+            ros::Time start_time = ros::Time::now();
+
+            uint32_t ros_height = end_beam - start_beam + 1;
+
+            if(debug){
+                ROS_INFO("Original data size: %zu bytes", cloud_msg.data.size());
+                ROS_INFO("Expected row size: %u bytes", cloud_msg.row_step);
+                ROS_INFO("Expected total size: %u bytes", cloud_msg.row_step * cloud_msg.height);
+            }
+
+            sensor_msgs::PointsCloud2 filtered_cloud;
+
+            //copy metadata
+            filtered_cloud.header = cloud_msg.header;
+            filtered_cloud.height = ros_height;
+            filtered_cloud.width = cloud_msg.width;
+            filtered_cloud.fields = cloud_msg.fields;
+            filtered_cloud.is_bigendian = cloud_msg.is_bigendian;
+            filtered_cloud.point_step = cloud_msg.point_step;
+            filtered_cloud.row_step = cloud_msg.row_step;
+            filtered_cloud.is_dense = cloud_msg.is_dense;
+
+            // allocate memory for the filtered cloud
+            filtered_cloud.data.resize(cloud_msg.row_step * ros_height);
+
+            // copy only the rows in the ROI
+            for (uint32_t i=0, beam_idx = start_beam; beam_idx < end_beam; ++i, ++beam_idx){
+                unit32_t start = beam_idx * filtered_cloud.row_step;
+                unit32_t end = start + filtered_cloud.row_step;
+                unit32_t dest = i * filtered_cloud.row_step;
+
+                if (dubug && i<2){  //just print first 2 beams to avoid log spam
+                    ROS_INFO("Copying beam %u (index %u) from %u to %u ", beam_idx, i, start, end);
+                }
+
+                std::copy(cloud_msg.data.begin() + start, cloud_msg.data.begin() + end, filtered_cloud.data.begin() + dest);
+            }
+
+            return filtered_cloud;
+        } catch (const std::exception& e) {
+            ROS_ERROR("Failed to shrink the FOV: %s", e.what());
+            return cloud_msg; // return orignal on error
+        }
+    }
+// ============ end of FOV shrinker =============
+
+
 int main(int argc, char** argv) {
     ros::init(argc, argv, "os_cloud_node");
     ros::NodeHandle nh("~");

--- a/ouster_ros/src/os_cloud_node.cpp
+++ b/ouster_ros/src/os_cloud_node.cpp
@@ -79,16 +79,16 @@ namespace sensor = ouster::sensor;
                 }
 
                 std::copy(cloud_msg.data.begin() + start, cloud_msg.data.begin() + end, filtered_cloud.data.begin() + dest);
+            }
 
-                if (debug){
-                    ros::Duration duration = ros::Time::now() - start_time;
-                    ROS_INFO("-----------------FOV shrinker performance-----------------");
-                    ROS_INFO("Input point cloud size: %u", cloud_msg.width * cloud_msg.height);
-                    ROS_INFO("Input point cloud size: %u x %u", cloud_msg.width, cloud_msg.height);
-                    ROS_INFO("Filtered point cloud: %u points", filtered_cloud.width * filtered_cloud.height);
-                    ROS_INFO("Filtered point cloud size: %u x %u", filtered_cloud.width, filtered_cloud.height);
-                    ROS_INFO("Time taken: %.2f ms", duration.toSec() * 1000.0);
-                }
+            if (debug){
+                ros::Duration duration = ros::Time::now() - start_time;
+                ROS_INFO("-----------------FOV shrinker performance-----------------");
+                ROS_INFO("Input point cloud size: %u", cloud_msg.width * cloud_msg.height);
+                ROS_INFO("Input point cloud size: %u x %u", cloud_msg.width, cloud_msg.height);
+                ROS_INFO("Filtered point cloud: %u points", filtered_cloud.width * filtered_cloud.height);
+                ROS_INFO("Filtered point cloud size: %u x %u", filtered_cloud.width, filtered_cloud.height);
+                ROS_INFO("Time taken: %.2f ms", duration.toSec() * 1000.0);
             }
 
             return filtered_cloud;
@@ -136,24 +136,26 @@ int main(int argc, char** argv) {
         return std::to_string(ind + 1);  // need second return to return 2
     };
 
-    auto lidar_pubs = std::vector<ros::Publisher>();
-    for (int i = 0; i < n_returns; i++) {
-        auto pub = nh.advertise<sensor_msgs::PointCloud2>(
-            std::string("points") + img_suffix(i), 10);
-        lidar_pubs.push_back(pub);
-    }
+    // auto lidar_pubs = std::vector<ros::Publisher>();
+    // for (int i = 0; i < n_returns; i++) {
+    //     auto pub = nh.advertise<sensor_msgs::PointCloud2>(
+    //         std::string("points") + img_suffix(i), 10);
+    //     lidar_pubs.push_back(pub);
+    // }
 
     //============= part of FOV shrinker ===================
     // parameter for beam selection
 
     uint32_t n_beams = H;
-    uint32_t start_beam = nh.param("start_beam", (int)(n_beams/4));
-    uint32_t end_beam = nh.param("end_beam", (int)(start_beam + n_beams/2));
+    int start_beam_int = nh.param("start_beam", (int)(n_beams/4));
+    int end_beam_int = nh.param("end_beam", (int)(start_beam_int + n_beams/2));
+    uint32_t start_beam = static_cast<uint32_t>(std::max(0, start_beam_int));
+    uint32_t end_beam = static_cast<uint32_t>(std::max(0, end_beam_int));
     bool debug_mode = nh.param("debug_mode", false);
 
     std::vector<ros::Publisher> fov_pubs;
     for (int i = 0; i < n_returns; i++){
-        auto pub = nh.advertise<sensor_msgs::PointCloud2>(std::string("fov_points")+img_suffix(i), 10);
+        auto pub = nh.advertise<sensor_msgs::PointCloud2>(std::string("points")+img_suffix(i), 10);
         fov_pubs.push_back(pub);
     }
 
@@ -178,14 +180,14 @@ int main(int argc, char** argv) {
                 for (int i = 0; i < n_returns; i++) {
                     scan_to_cloud(xyz_lut, h->timestamp, ls, cloud, i);
                     //lidar_pubs[i].publish(ouster_ros::cloud_to_cloud_msg(
-                    //    cloud, h->timestamp, sensor_frame));
+                    //    cloud, h->timestamp, sensor_frame));                               // original publisher
 
 
                     // =============== part of FOV shrinker =================
                     auto cloud_msg = ouster_ros::cloud_to_cloud_msg(cloud, h->timestamp, sensor_frame);
 
-                    //publish the os_cloud
-                    lidar_pubs[i].publish(cloud_msg);
+                    // //publish the os_cloud
+                    // lidar_pubs[i].publish(cloud_msg);
 
                     //publish the FOV_clouds
                     auto filtered_cloud = FOV_shrinker(cloud_msg, start_beam, end_beam, debug_mode);

--- a/ouster_ros/src/os_cloud_node.cpp
+++ b/ouster_ros/src/os_cloud_node.cpp
@@ -167,9 +167,18 @@ int main(int argc, char** argv) {
             if (h != ls.headers.end()) {
                 for (int i = 0; i < n_returns; i++) {
                     scan_to_cloud(xyz_lut, h->timestamp, ls, cloud, i);
-                    lidar_pubs[i].publish(ouster_ros::cloud_to_cloud_msg(
-                        cloud, h->timestamp, sensor_frame));
+                    //lidar_pubs[i].publish(ouster_ros::cloud_to_cloud_msg(
+                    //    cloud, h->timestamp, sensor_frame));
                     // =============== part of FOV shrinker =================
+                    auto cloud_msg = ouster_ros::cloud_to_cloud_msg(cloud, h->timestamp, sensor_frame);
+
+                    //publish the os_cloud
+                    lidar_pubs[i].publish(cloud_msg);
+
+                    //publish
+                    auto filtered_cloud = FOV_shrinker(cloud_msg, start_beam, end_beam, debug_mode);
+                    fov_pubs[i].publish(filtered_cloud);
+
 
                 }
             }

--- a/ouster_ros/src/os_cloud_node.cpp
+++ b/ouster_ros/src/os_cloud_node.cpp
@@ -37,10 +37,10 @@ namespace sensor = ouster::sensor;
  * @param debug Enable debug messages
  */
 
- sensor_msg::PointsClouds FOV_shrinker(
+ sensor_msgs::PointCloud2 FOV_shrinker(
     const sensor_msgs::PointCloud2& cloud_msg,
-    unit32_t start_beam,
-    unit32_t end_beam,
+    uint32_t start_beam,
+    uint32_t end_beam,
     bool debug = false){
         try{
             ros::Time start_time = ros::Time::now();
@@ -53,7 +53,7 @@ namespace sensor = ouster::sensor;
                 ROS_INFO("Expected total size: %u bytes", cloud_msg.row_step * cloud_msg.height);
             }
 
-            sensor_msgs::PointsCloud2 filtered_cloud;
+            sensor_msgs::PointCloud2 filtered_cloud;
 
             //copy metadata
             filtered_cloud.header = cloud_msg.header;
@@ -69,16 +69,26 @@ namespace sensor = ouster::sensor;
             filtered_cloud.data.resize(cloud_msg.row_step * ros_height);
 
             // copy only the rows in the ROI
-            for (uint32_t i=0, beam_idx = start_beam; beam_idx < end_beam; ++i, ++beam_idx){
-                unit32_t start = beam_idx * filtered_cloud.row_step;
-                unit32_t end = start + filtered_cloud.row_step;
-                unit32_t dest = i * filtered_cloud.row_step;
+            for (uint32_t i=0, beam_idx = start_beam; beam_idx <= end_beam; ++i, ++beam_idx){
+                uint32_t start = beam_idx * filtered_cloud.row_step;
+                uint32_t end = start + filtered_cloud.row_step;
+                uint32_t dest = i * filtered_cloud.row_step;
 
-                if (dubug && i<2){  //just print first 2 beams to avoid log spam
+                if (debug && i<2){  //just print first 2 beams to avoid log spam
                     ROS_INFO("Copying beam %u (index %u) from %u to %u ", beam_idx, i, start, end);
                 }
 
                 std::copy(cloud_msg.data.begin() + start, cloud_msg.data.begin() + end, filtered_cloud.data.begin() + dest);
+
+                if (debug){
+                    ros::Duration duration = ros::Time::now() - start_time;
+                    ROS_INFO("-----------------FOV shrinker performance-----------------");
+                    ROS_INFO("Input point cloud size: %u", cloud_msg.width * cloud_msg.height);
+                    ROS_INFO("Input point cloud size: %u x %u", cloud_msg.width, cloud_msg.height);
+                    ROS_INFO("Filtered point cloud: %u points", filtered_cloud.width * filtered_cloud.height);
+                    ROS_INFO("Filtered point cloud size: %u x %u", filtered_cloud.width, filtered_cloud.height);
+                    ROS_INFO("Time taken: %.2f ms", duration.toSec() * 1000.0);
+                }
             }
 
             return filtered_cloud;
@@ -137,13 +147,13 @@ int main(int argc, char** argv) {
     // parameter for beam selection
 
     uint32_t n_beams = H;
-    unit32_t start_beam = nh.param("start_beam", n_beams/4);
-    unit32_t end_beam = nh.param("end_beam", start_beam + n_beams/2);
+    uint32_t start_beam = nh.param("start_beam", (int)(n_beams/4));
+    uint32_t end_beam = nh.param("end_beam", (int)(start_beam + n_beams/2));
     bool debug_mode = nh.param("debug_mode", false);
 
     std::vector<ros::Publisher> fov_pubs;
     for (int i = 0; i < n_returns; i++){
-        auto pub = nh.advertise<sensor_msgs::PointCloud2>(std::sring("fov_points")+img_suffix(i), 10);
+        auto pub = nh.advertise<sensor_msgs::PointCloud2>(std::string("fov_points")+img_suffix(i), 10);
         fov_pubs.push_back(pub);
     }
 
@@ -169,15 +179,18 @@ int main(int argc, char** argv) {
                     scan_to_cloud(xyz_lut, h->timestamp, ls, cloud, i);
                     //lidar_pubs[i].publish(ouster_ros::cloud_to_cloud_msg(
                     //    cloud, h->timestamp, sensor_frame));
+
+
                     // =============== part of FOV shrinker =================
                     auto cloud_msg = ouster_ros::cloud_to_cloud_msg(cloud, h->timestamp, sensor_frame);
 
                     //publish the os_cloud
                     lidar_pubs[i].publish(cloud_msg);
 
-                    //publish
+                    //publish the FOV_clouds
                     auto filtered_cloud = FOV_shrinker(cloud_msg, start_beam, end_beam, debug_mode);
                     fov_pubs[i].publish(filtered_cloud);
+                    // =============== FOV shrinker =======================
 
 
                 }

--- a/ouster_ros/src/os_cloud_node.cpp
+++ b/ouster_ros/src/os_cloud_node.cpp
@@ -29,7 +29,7 @@ using Point = ouster_ros::Point;
 namespace sensor = ouster::sensor;
 
 
-//============== begin new FOV shrinker ====================
+//============== part of new FOV shrinker ====================
 /**
  * @brief Filter point clouds, to keep only the middle horizontal beams in the Field of View (FOV)
  * @param start_beam starting beam index in FOV
@@ -87,7 +87,7 @@ namespace sensor = ouster::sensor;
             return cloud_msg; // return orignal on error
         }
     }
-// ============ end of FOV shrinker =============
+// ============ FOV shrinker =============
 
 
 int main(int argc, char** argv) {
@@ -133,6 +133,24 @@ int main(int argc, char** argv) {
         lidar_pubs.push_back(pub);
     }
 
+    //============= part of FOV shrinker ===================
+    // parameter for beam selection
+
+    uint32_t n_beams = H;
+    unit32_t start_beam = nh.param("start_beam", n_beams/4);
+    unit32_t end_beam = nh.param("end_beam", start_beam + n_beams/2);
+    bool debug_mode = nh.param("debug_mode", false);
+
+    std::vector<ros::Publisher> fov_pubs;
+    for (int i = 0; i < n_returns; i++){
+        auto pub = nh.advertise<sensor_msgs::PointCloud2>(std::sring("fov_points")+img_suffix(i), 10);
+        fov_pubs.push_back(pub);
+    }
+
+    ROS_INFO("FOV point cloud filtering initialized");
+    ROS_INFO("Keeping beams %u to %u (of %u beams)", start_beam, end_beam-1, n_beams);
+   // ============= FOV shrinker ===================
+
     auto xyz_lut = ouster::make_xyz_lut(info);
 
     ouster::LidarScan ls{W, H, udp_profile_lidar};
@@ -151,6 +169,8 @@ int main(int argc, char** argv) {
                     scan_to_cloud(xyz_lut, h->timestamp, ls, cloud, i);
                     lidar_pubs[i].publish(ouster_ros::cloud_to_cloud_msg(
                         cloud, h->timestamp, sensor_frame));
+                    // =============== part of FOV shrinker =================
+
                 }
             }
         }


### PR DESCRIPTION
## Description

Added a Field of View (FOV) shrinker feature that optimizes point cloud processing by publishing only a subset of lidar beams. By default, only the middle half of beams (32/64) are published to the `os_cloud_node/points` topic. This significantly reduces bandwidth usage and accelerates downstream point cloud processing operations.


## Type of change
New feature: FOV shrinker implementation.

## How Has This Been Tested?
The feature has been thoroughly tested on live lidar scan data. 

**Testing Instructions:**
```bash
roslaunch adeye lidar_demonstration.launch
```
You can customize which beams to retain by modifying the following parameters:
```
<param name="~/start_beam" value="38"/>
<param name="~/end_beam" value="58"/> 
```

## Pull request Review Checklist:

#### Git
- [x] Branch name: the name of the branch is descriptive
- [x] Commit history: the history is clean and the commit have descriptive messages
- [x] Authors: the commits have the proper author

#### General Pull Request steps
- [x] Files: all the files modified are needed for the feature/bugfix
- [x] Build: for C++ code, the code builds without error (`catkin_make`)
- [x] Run: the feature runs without error and performs the intended task

#### Code specific steps
- [x] Code conventions: the code follows the project conventions (https://gits-15.sys.kth.se/AD-EYE/AD-EYE_Core/wiki/Conventions)
- [x] Variable names: the variables have descriptive names
- [x] No magic numbers: there is no value in the code that is not assigned to a constant variable
- [x] Doxygen tags: the code has tags for Doxygen as described on https://gits-15.sys.kth.se/AD-EYE/AD-EYE_Core/wiki/Code-Documentation (only for C++ and Python)
- [x] Logic: the code logic performs the intended task and cannot be simplified